### PR TITLE
Add canvas streaming helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ This project underwent code refactoring after version `v1.0.0` and is currently 
   - 🗣️ AI proactive speaking feature
   - 💾 Chat log persistence, switch to previous conversations anytime
   - 🌍 TTS translation support (e.g., chat in Chinese while AI uses Japanese voice)
+  - 📡 Multi-platform livestream helper scripts in `streaming/` (headless and canvas capture)
 
 - 🧠 **Extensive model support**:
   - 🤖 Large Language Models (LLM): Ollama, OpenAI (and any OpenAI-compatible API), Gemini, Claude, Mistral, DeepSeek, Zhipu AI, GGUF, LM Studio, vLLM, etc.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "pydub>=0.25.1",
     "pysbd>=0.3.4",
     "pyttsx3>=2.98",
+    "pyppeteer>=1.0.2",
     "pyyaml>=6.0.2",
     "requests>=2.32.3",
     "ruff>=0.8.6",

--- a/streaming/README.md
+++ b/streaming/README.md
@@ -1,0 +1,46 @@
+# Streaming Utilities
+
+This folder contains helper scripts for livestreaming to multiple platforms.
+
+## multistream.py
+
+Use `multistream.py` to forward a single video input to multiple RTMP
+endpoints using `ffmpeg`. This can be used to save resources when streaming to
+several services simultaneously.
+
+### Example
+
+```bash
+python multistream.py video.mp4 --rtmp rtmp://a.example/live/streamkey \
+    rtmp://b.example/app/key
+```
+
+`ffmpeg` must be installed and available on your `PATH`.
+
+## headless_multistream.py
+
+`headless_multistream.py` launches a virtual display using `Xvfb`, opens a web page with a Live2D character in a browser, and streams that headless session to multiple RTMP endpoints.
+
+### Example
+
+```bash
+python headless_multistream.py https://example.com/character \
+    --rtmp rtmp://a.example/live/key rtmp://b.example/app/key
+```
+
+Both `ffmpeg` and `Xvfb` must be installed.
+
+## canvas_multistream.py
+
+`canvas_multistream.py` uses the Chrome DevTools protocol via `pyppeteer` to
+capture the canvas from a web page and stream it directly to multiple RTMP
+destinations.
+
+### Example
+
+```bash
+python canvas_multistream.py https://example.com/character \
+    --rtmp rtmp://a.example/live/key rtmp://b.example/app/key
+```
+
+`ffmpeg` and `pyppeteer` are required.

--- a/streaming/canvas_multistream.py
+++ b/streaming/canvas_multistream.py
@@ -1,0 +1,76 @@
+import argparse
+import asyncio
+import base64
+import subprocess
+from typing import List
+
+from pyppeteer import launch
+
+
+async def start_canvas_stream(url: str, rtmp_urls: List[str], fps: int) -> None:
+    """Capture canvas rendering from a web page and stream to multiple RTMP endpoints."""
+    if not rtmp_urls:
+        raise ValueError("No RTMP URLs provided")
+
+    outputs = "|".join(f"[f=flv]{u}" for u in rtmp_urls)
+    ffmpeg_cmd = [
+        "ffmpeg",
+        "-y",
+        "-f",
+        "image2pipe",
+        "-vcodec",
+        "mjpeg",
+        "-r",
+        str(fps),
+        "-i",
+        "-",
+        "-c:v",
+        "libx264",
+        "-preset",
+        "veryfast",
+        "-pix_fmt",
+        "yuv420p",
+        "-f",
+        "tee",
+        outputs,
+    ]
+    proc = subprocess.Popen(ffmpeg_cmd, stdin=subprocess.PIPE)
+
+    browser = await launch(headless=True, args=["--no-sandbox"])
+    page = await browser.newPage()
+    await page.goto(url)
+
+    client = await page.target.createCDPSession()
+    await client.send("Page.startScreencast", {"format": "jpeg", "quality": 80})
+    try:
+        while True:
+            msg = await client.recv()
+            if msg.get("method") == "Page.screencastFrame":
+                data = base64.b64decode(msg["params"]["data"])
+                proc.stdin.write(data)
+                proc.stdin.flush()
+                await client.send(
+                    "Page.screencastFrameAck",
+                    {"sessionId": msg["params"]["sessionId"]},
+                )
+    finally:
+        await browser.close()
+        proc.stdin.close()
+        proc.wait()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Capture canvas render and livestream to multiple platforms"
+    )
+    parser.add_argument("url", help="URL of the page containing the canvas")
+    parser.add_argument("--rtmp", nargs="+", required=True, help="RTMP URLs")
+    parser.add_argument("--fps", type=int, default=30, help="Frames per second")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    asyncio.get_event_loop().run_until_complete(
+        start_canvas_stream(args.url, args.rtmp, args.fps)
+    )

--- a/streaming/headless_multistream.py
+++ b/streaming/headless_multistream.py
@@ -1,0 +1,59 @@
+import argparse
+import os
+import subprocess
+from typing import List
+
+
+def start_headless_stream(url: str, rtmp_urls: List[str], resolution: str, display: str, fps: int) -> None:
+    """Launch a headless browser in a virtual display and stream it via ffmpeg."""
+    if not rtmp_urls:
+        raise ValueError("No RTMP URLs provided")
+
+    # Start Xvfb virtual display
+    xvfb_cmd = ["Xvfb", display, "-screen", "0", f"{resolution}x24", "-ac"]
+    xvfb_proc = subprocess.Popen(xvfb_cmd)
+
+    env = os.environ.copy()
+    env["DISPLAY"] = display
+
+    try:
+        # Launch browser within the virtual display
+        browser_cmd = ["chromium-browser", url]
+        browser_proc = subprocess.Popen(browser_cmd, env=env)
+
+        outputs = "|".join(f"[f=flv]{u}" for u in rtmp_urls)
+        ffmpeg_cmd = [
+            "ffmpeg",
+            "-f",
+            "x11grab",
+            "-video_size",
+            resolution,
+            "-i",
+            f"{display}.0",
+            "-r",
+            str(fps),
+            "-f",
+            "tee",
+            outputs,
+        ]
+        subprocess.run(ffmpeg_cmd, check=True, env=env)
+    finally:
+        browser_proc.terminate()
+        xvfb_proc.terminate()
+        browser_proc.wait()
+        xvfb_proc.wait()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Headless multi-platform streaming")
+    parser.add_argument("url", help="URL of the page to render")
+    parser.add_argument("--rtmp", nargs="+", required=True, help="RTMP URLs")
+    parser.add_argument("--resolution", default="1280x720", help="Video resolution WxH")
+    parser.add_argument("--display", default=":99", help="X11 display number for Xvfb")
+    parser.add_argument("--fps", type=int, default=30, help="Output frames per second")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    start_headless_stream(args.url, args.rtmp, args.resolution, args.display, args.fps)

--- a/streaming/multistream.py
+++ b/streaming/multistream.py
@@ -1,0 +1,36 @@
+import argparse
+import subprocess
+from typing import List
+
+
+def start_multistream(input_source: str, rtmp_urls: List[str]) -> None:
+    """Stream input source to multiple RTMP endpoints using ffmpeg."""
+    if not rtmp_urls:
+        raise ValueError("No RTMP URLs provided")
+    outputs = "|".join(f"[f=flv]{url}" for url in rtmp_urls)
+    cmd = [
+        "ffmpeg",
+        "-re",
+        "-i",
+        input_source,
+        "-c:v",
+        "copy",
+        "-c:a",
+        "copy",
+        "-f",
+        "tee",
+        outputs,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Multi-platform livestream helper")
+    parser.add_argument("input", help="Input video source (file path or URL)")
+    parser.add_argument("--rtmp", nargs="+", required=True, help="RTMP URLs")
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    start_multistream(args.input, args.rtmp)


### PR DESCRIPTION
## Summary
- add `canvas_multistream.py` for streaming canvas via Chrome devtools
- document it in `streaming/README.md`
- mention canvas capture in the main README
- include `pyppeteer` dependency

## Testing
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_687868181a308331ad24208c4adf4177